### PR TITLE
GL context creation on windows

### DIFF
--- a/example/nox.zig
+++ b/example/nox.zig
@@ -12,5 +12,8 @@ pub fn main() anyerror!void {
         .height = 600,
         .title = "Zig window",
     });
+
+    const ctx = try win.makeGLContext(3, 1);
+
     while (window.loop()) {}
 }

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -53,7 +53,6 @@ extern "user32" fn GetMonitorInfoA(monitor: HMONITOR, lpmi: *MonitorInfoEx) bool
 extern "user32" fn BeginPaint(hWnd: HWND, lpPaint: *PaintStruct) HDC;
 extern "user32" fn EndPaint(hWnd: HWND, lpPaint: *const PaintStruct) bool;
 extern "user32" fn EnumDisplayMonitors(hdc: ?HDC, lprcClip: ?*const Rect, lpfnEnum: MonitorEnumProc, dwData: LPARAM) bool;
-// TODO: Check if those are actually in gdi32
 extern "opengl32" fn wglCreateContext(hdc: HDC) callconv(.Stdcall) ?HGLRC;
 extern "opengl32" fn wglMakeCurrent(?HDC, ?HGLRC) callconv(.Stdcall) bool;
 extern "opengl32" fn wglDeleteContext(HGLRC) callconv(.Stdcall) bool;


### PR DESCRIPTION
Currently depends on https://github.com/ziglang/zig/pull/5759 (should be pulled soon, small fix)  

Current api

```zig
Window {
    pub fn makeGLContext(win: Window, major_version: u8, minor_version: u8) !GLContext
}

GLContext {
    pub fn enable(self: GLContext) !void 
    pub fn disable(self: GLContext) !void
    pub fn deinit(self: GLContext) void 
}
```
The context is enabled before being returned by `makeGLContext`.  

Changes that may be good:  
Take a `GLContextOptions` struct that wraps the types as well as other options (TODO: decide on some optiosn to start with)